### PR TITLE
Add log4j2 support and bump version to 2.0.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -147,3 +147,27 @@ log4j.appender.clouderaRedactor.policy.rules=/full/path/to/rules.json
 
 log4j.rootLogger=CONS, rootRedactor
 log4j.logger.org.cloudera=RFA, clouderaRedactor
+
+LOG4J2 SUPPORT:
+
+Log redaction is supported in log4j2 via the
+org.cloudera.log4j2.redactor.RedactorPolicy class (note the "log4j2" in the
+class name, which differentiates it from the log4j version). This class is an
+implementation of RewritePolicy and is meant to be used with the built-in
+RewriteAppender class in log4j2. Simply instantiate a RewriteAppender, specify
+the RedactorPolicy with the correct rules file, and specify in the
+RewriteAppender the appenders that should receive the redacted log messages.
+
+An example, which redacts messages and passes them on to the console and a
+rolling file appender, is provided below:
+
+appender.redactorForRootLogger.name=redactorForRootLogger
+appender.redactorForRootLogger.type=Rewrite
+appender.redactorForRootLogger.appenderRef-console.type=AppenderRef
+appender.redactorForRootLogger.appenderRef-console.ref=console
+appender.redactorForRootLogger.appenderRef-console.level=ERROR
+appender.redactorForRootLogger.appenderRef-DRFA.type=AppenderRef
+appender.redactorForRootLogger.appenderRef-DRFA.ref=DRFA
+appender.redactorForRootLogger.rewritePolicy.name=redactorForRootLoggerPolicy
+appender.redactorForRootLogger.rewritePolicy.type=RedactorPolicy
+appender.redactorForRootLogger.rewritePolicy.rules=/full/path/to/rules.json

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.cloudera.logredactor</groupId>
   <artifactId>logredactor</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <description>Log Redactor</description>
   <name>Log Redactor</name>
   <packaging>jar</packaging>
@@ -82,6 +82,18 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/cloudera/log4j2/redactor/RedactorPolicy.java
+++ b/src/main/java/org/cloudera/log4j2/redactor/RedactorPolicy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+package org.cloudera.log4j2.redactor;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.rewrite.RewritePolicy;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.cloudera.log4j.redactor.StringRedactor;
+
+/**
+ * <code>RewritePolicy</code> implementation that applies the redaction
+ * rules defined in the configuration of the <code>RedactorPolicy</code> in
+ * the Log4j Properties configuration file. Use with RewriteAppender.
+ */
+@Plugin(name = "RedactorPolicy", category = "Core", elementType = "layout", printObject = true)
+public class RedactorPolicy implements RewritePolicy {
+
+  // 'rules' is really the name of the file containing the rules
+  private String rules;
+  private StringRedactor redactor;
+
+  @PluginFactory
+  public static RedactorPolicy createPolicy(@PluginAttribute("name") String name,
+                                            @PluginAttribute("rules") String rules) {
+    return new RedactorPolicy(rules);
+  }
+
+  protected RedactorPolicy(String rules) {
+    this.rules = rules;
+    try {
+      this.redactor = StringRedactor.createFromJsonFile(rules);
+    } catch (IOException e) {
+      // Changing the exception, since activateOptions can't throw an IOException
+      throw new IllegalArgumentException("Problem with rules file " + rules, e);
+    }
+  }
+
+  /**
+   * Given a LoggingEvent, potentially modify it and return an altered copy.
+   * This implements the RewritePolicy interface.
+   * @param source LoggingEvent to examine
+   * @return Either the original (no changes) or a redacted copy.
+   */
+  @Override
+  public LogEvent rewrite(LogEvent source) {
+    String original = source.getMessage().getFormattedMessage();
+    String redacted = redactor.redact(original);
+    if (!redacted.equals(original)) {
+      source = new Log4jLogEvent.Builder(source)
+          .setMessage(new SimpleMessage(redacted))
+          .build();
+    }
+    return source;
+  }
+}

--- a/src/test/java/org/cloudera/log4j/redactor/BaseRedactorTest.java
+++ b/src/test/java/org/cloudera/log4j/redactor/BaseRedactorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+package org.cloudera.log4j.redactor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FilterOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+public abstract class BaseRedactorTest {
+  protected static String resourcePath = "/";
+
+  protected Properties defaults = new Properties();
+  private PrintStream originalOut;
+  private PrintStream originalErr;
+  private ByteArrayOutputStream memOut;
+  private FilterOut filterOut;
+  private PrintStream capturedOut;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    originalOut = System.out;
+    originalErr = System.err;
+    memOut = new ByteArrayOutputStream();
+    filterOut = new FilterOut(memOut);
+    capturedOut = new PrintStream(filterOut);
+    System.setOut(capturedOut);
+    System.setErr(capturedOut);
+
+    URL resourceUrl = getClass().getResource("/real-1.json");
+    File resourceFile = new File(resourceUrl.toURI());
+    resourcePath = resourceFile.getParent();
+
+    setupLogger();
+  }
+
+  protected abstract void setupLogger();
+
+  @After
+  public void cleanUp() {
+    System.setErr(originalErr);
+    System.setOut(originalOut);
+  }
+
+  protected String getAndResetLogOutput() {
+    capturedOut.flush();
+    String logOutput = new String(memOut.toByteArray());
+    memOut = new ByteArrayOutputStream();
+    filterOut.setOutputStream(memOut);
+    return logOutput;
+  }
+
+  protected void testRedactionRules(LoggerWrapper log) {
+    log.info("WHERE x=123-45-6789");
+    String out = getAndResetLogOutput();
+    Assert.assertEquals("WHERE x=XXX-XX-XXXX", out);
+
+    log.info("x=123-45-6789 WHERE");
+    out = getAndResetLogOutput();
+    Assert.assertEquals("x=XXX-XX-XXXX WHERE", out);
+
+    log.info("WHERE x=123-45-6789 or y=000-00-0000");
+    out = getAndResetLogOutput();
+    Assert.assertEquals("WHERE x=XXX-XX-XXXX or y=XXX-XX-XXXX", out);
+
+    log.info("x=1234-1234-1234-1234 or y=000-00-0000");
+    out = getAndResetLogOutput();
+    Assert.assertEquals("x=XXXX-XXXX-XXXX-XXXX or y=XXX-XX-XXXX", out);
+
+    log.info("xxx password=\"hi\"");
+    out = getAndResetLogOutput();
+    Assert.assertEquals("xxx password=xxxxx", out);
+
+    log.info("Mail me at myoder@cloudera.com, dude.");
+    out = getAndResetLogOutput();
+    Assert.assertEquals("Mail me at email@redacted.host, dude.", out);
+  }
+
+  private static class FilterOut extends FilterOutputStream {
+    public FilterOut(OutputStream out) {
+      super(out);
+    }
+
+    public void setOutputStream(OutputStream out) {
+      this.out = out;
+    }
+  }
+
+  // Since log4j and log4j2 use different Logger classes, we put a wrapper around them to avoid
+  // test code duplication
+  protected static abstract class LoggerWrapper {
+    public abstract void info(String message);
+  }
+}

--- a/src/test/java/org/cloudera/log4j/redactor/Log4j2RedactorTest.java
+++ b/src/test/java/org/cloudera/log4j/redactor/Log4j2RedactorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2017, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+package org.cloudera.log4j.redactor;
+
+import java.net.URI;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Log4j2RedactorTest extends BaseRedactorTest {
+
+  protected void setupLogger() {
+    // Setup happens before each test
+  }
+
+  /**
+   * Runs all log4j2 tests.
+   *
+   * Due to being unable to reset the logger properly between test cases, all the tests need to
+   * run in the same test method, and the good test must run first.
+   */
+  @Test
+  public void testLog4j2() {
+    testRedaction();
+
+    testNoFile();
+
+    testBadFile();
+  }
+
+  /**
+   * Validate that redaction does in fact occur. Rigorous testing of the
+   * redaction rules file and redaction itself is over in the
+   * <code>StringRedactorTest</code>.
+   */
+  public void testRedaction() {
+    ConfigurationFactory.setConfigurationFactory(new TestConfigurationFactory());
+    ((LoggerContext)LogManager.getContext()).reconfigure();
+    final Logger log = LogManager.getLogger("testRedaction");
+
+    testRedactionRules(new LoggerWrapper() {
+      public void info(String message) {
+        log.info(message);
+      }
+    });
+  }
+
+  /**
+   * Ensure expected exception behavior with a file that doesn't exist. In log4j2, the exception
+   * is no longer propagated, but instead logged to stdout, so we scan stdout for the exception.
+   */
+  public void testNoFile() {
+    ConfigurationFactory.setConfigurationFactory(new NoFileConfigurationFactory());
+    ((LoggerContext)LogManager.getContext()).reconfigure();
+    Logger log = LogManager.getLogger("testNoFile");
+    log.info("WHERE x=123-45-6789");
+
+    String out = getAndResetLogOutput();
+    Assert.assertTrue(out.contains(IllegalArgumentException.class.getCanonicalName()));
+    Assert.assertTrue(out.contains("/thisfiledoesnotexist.json"));
+  }
+
+  /**
+   * Ensure expected exception behavior with an invalid file. In log4j2, the exception is no
+   * longer propagated, but instead logged to stdout, so we scan stdout for the exception.
+   */
+  public void testBadFile() {
+    ConfigurationFactory.setConfigurationFactory(new BadFileConfigurationFactory());
+    ((LoggerContext)LogManager.getContext()).reconfigure();
+    Logger log = LogManager.getLogger("testBadFile");
+    log.info("WHERE x=123-45-6789");
+
+    String out = getAndResetLogOutput();
+    Assert.assertTrue(out.contains(IllegalArgumentException.class.getCanonicalName()));
+    Assert.assertTrue(out.contains("/non-json.json"));
+  }
+
+  /**
+   * Creates a custom log4j2 configuration which registers a RewriteAppender and a
+   * RedactorPolicy.
+   */
+  protected static class TestConfigurationFactory extends ConfigurationFactory {
+    @Override
+    protected String[] getSupportedTypes() {
+      return new String[]{"*"};
+    }
+
+    @Override
+    public Configuration getConfiguration(LoggerContext loggerContext,
+                                          ConfigurationSource source) {
+      return buildConfiguration();
+    }
+
+    @Override
+    public Configuration getConfiguration(LoggerContext loggerContext, String name, URI configLocation) {
+      return buildConfiguration();
+    }
+
+    @Override
+    public Configuration getConfiguration(LoggerContext loggerContext, String name, URI configLocation, ClassLoader loader) {
+      return buildConfiguration();
+    }
+
+    protected Configuration buildConfiguration() {
+      ConfigurationBuilder<BuiltConfiguration> builder = newConfigurationBuilder();
+      builder.setConfigurationName(Log4j2RedactorTest.class.getName());
+      builder.setStatusLevel(Level.INFO);
+
+      AppenderComponentBuilder appenderBuilder = builder.newAppender("Stderr", "CONSOLE")
+          .addAttribute("target", ConsoleAppender.Target.SYSTEM_ERR);
+      appenderBuilder.add(builder.newLayout("PatternLayout")
+          .addAttribute("pattern", "%msg"));
+      builder.add(appenderBuilder);
+
+      AppenderComponentBuilder rewriteBuilder = builder.newAppender("Redactor", "Rewrite")
+          .addComponent(builder.newComponent("RedactorPolicy", "RedactorPolicy")
+              .addAttribute("rules", resourcePath + getPolicyFilename()))
+          .addComponent(builder.newAppenderRef("Stderr"));
+      builder.add(rewriteBuilder);
+
+      builder.add(builder.newRootLogger(Level.INFO)
+          .add(builder.newAppenderRef("Redactor")));
+
+      return builder.build();
+    }
+
+    /**
+     * Returns the filename of the redaction policy file.
+     *
+     * This is silly, but ConfigurationFactory subclasses must have a default no-argument
+     * constructor, which prevents us from passing the filename as an argument. Thus, we
+     * subclass and override this method so that we can test different policy files.
+     */
+    protected String getPolicyFilename() {
+      return "/real-1.json";
+    }
+  }
+
+  protected static final class NoFileConfigurationFactory extends TestConfigurationFactory {
+    protected String getPolicyFilename() {
+      return "/thisfiledoesnotexist.json";
+    }
+  }
+
+  protected static final class BadFileConfigurationFactory extends TestConfigurationFactory {
+    protected String getPolicyFilename() {
+      return "/non-json.json";
+    }
+  }
+}

--- a/src/test/java/org/cloudera/log4j/redactor/RedactorAppenderTest.java
+++ b/src/test/java/org/cloudera/log4j/redactor/RedactorAppenderTest.java
@@ -14,56 +14,18 @@
  */
 package org.cloudera.log4j.redactor;
 
+import java.util.Properties;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FilterOutputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.net.URL;
-import java.util.Properties;
+public class RedactorAppenderTest extends BaseRedactorTest {
+  protected static final String PRE = "log4j.appender.";
 
-public class RedactorAppenderTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  private PrintStream originalOut;
-  private ByteArrayOutputStream memOut;
-  private FilterOut filterOut;
-  private PrintStream capturedOut;
-
-  private static class FilterOut extends FilterOutputStream {
-    public FilterOut(OutputStream out) {
-      super(out);
-    }
-
-    public void setOutputStream(OutputStream out) {
-      this.out = out;
-    }
-  }
-
-  private Properties defaults = new Properties();
-  private static final String PRE = "log4j.appender.";
-  private String resourcePath = "/";
-
-  @Before
-  public void setUp() throws Exception {
-    originalOut = System.err;
-    memOut = new ByteArrayOutputStream();
-    filterOut = new FilterOut(memOut);
-    capturedOut = new PrintStream(filterOut);
-    System.setErr(capturedOut);
-
+  @Override
+  protected void setupLogger() {
     final String pkg = "org.cloudera.log4j.redactor.";
     defaults.setProperty(PRE + "LOG", "org.apache.log4j.ConsoleAppender");
     defaults.setProperty(PRE + "LOG.Target", "System.err");
@@ -73,24 +35,12 @@ public class RedactorAppenderTest {
     defaults.setProperty(PRE + "redactor.appenderRefs", "LOG");
     defaults.setProperty(PRE + "redactor.policy", pkg + "RedactorPolicy");
     defaults.setProperty("log4j.rootLogger", "ALL, LOG, redactor");
-
-    URL resourceUrl = getClass().getResource("/real-1.json");
-    File resourceFile = new File(resourceUrl.toURI());
-    resourcePath = resourceFile.getParent();
   }
 
-  @After
+  @Override
   public void cleanUp() {
-    System.setErr(originalOut);
+    super.cleanUp();
     LogManager.resetConfiguration();
-  }
-
-  private String getAndResetLogOutput() {
-    capturedOut.flush();
-    String logOutput = new String(memOut.toByteArray());
-    memOut = new ByteArrayOutputStream();
-    filterOut.setOutputStream(memOut);
-    return logOutput;
   }
 
   /**
@@ -104,31 +54,13 @@ public class RedactorAppenderTest {
     logProps.setProperty(PRE + "redactor.policy.rules",
             resourcePath + "/real-1.json");
     PropertyConfigurator.configure(logProps);
-    Logger log = Logger.getLogger(RedactorAppenderTest.class);
+    final Logger log = Logger.getLogger(RedactorAppenderTest.class);
 
-    log.info("WHERE x=123-45-6789");
-    String out = getAndResetLogOutput();
-    Assert.assertEquals("WHERE x=XXX-XX-XXXX", out);
-
-    log.info("x=123-45-6789 WHERE");
-    out = getAndResetLogOutput();
-    Assert.assertEquals("x=XXX-XX-XXXX WHERE", out);
-
-    log.info("WHERE x=123-45-6789 or y=000-00-0000");
-    out = getAndResetLogOutput();
-    Assert.assertEquals("WHERE x=XXX-XX-XXXX or y=XXX-XX-XXXX", out);
-
-    log.info("x=1234-1234-1234-1234 or y=000-00-0000");
-    out = getAndResetLogOutput();
-    Assert.assertEquals("x=XXXX-XXXX-XXXX-XXXX or y=XXX-XX-XXXX", out);
-
-    log.info("xxx password=\"hi\"");
-    out = getAndResetLogOutput();
-    Assert.assertEquals("xxx password=xxxxx", out);
-
-    log.info("Mail me at myoder@cloudera.com, dude.");
-    out = getAndResetLogOutput();
-    Assert.assertEquals("Mail me at email@redacted.host, dude.", out);
+    testRedactionRules(new LoggerWrapper() {
+      public void info(String message) {
+        log.info(message);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This adds a new log4j2-compatible RedactorPolicy plugin. It is meant to be used
as the RewritePolicy for the RewriteAppender in log4j2.