### PR TITLE
Upgrade jackson-databind to 2.12.7.1 to fix CVE-2022-42003, CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.8</version>
+      <version>2.12.7.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

CVE-2022-42003 and CVE-2022-42004 are fixed in jackson-databind 2.12.7.1, 2.13.4.2 and 2.14.0-rc1.

This PR proposes upgrade to 2.12.7.1 to match Hadoop, which had problems with 2.13:
https://issues.apache.org/jira/browse/HADOOP-18493

## How was this patch tested?

```
$ mvn clean package
...
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.cloudera.log4j.redactor.StringRedactorTest
Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.676 sec
Running org.cloudera.log4j.redactor.Log4j2RedactorTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.161 sec
Running org.cloudera.log4j.redactor.RedactorAppenderTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec

Results :

Tests run: 39, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:3.0.2:jar (default-jar) @ logredactor ---
[INFO] Building jar: target/logredactor-2.0.14-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```