### PR TITLE
Make log4j dependencies optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -141,6 +142,7 @@
       <!-- Matches Hive, the primary user of log4j2 -->
       <version>2.17.1</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -148,6 +150,7 @@
       <!-- Matches Hive, the primary user of log4j2 -->
       <version>2.17.1</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logredactor implements redaction for both Log4j1 and Log4j2.  It needs compile-time dependency for both implementations. Projects that depend on Logredactor, however, may be using only one of those.  Currently they have to exclude the unwanted transitive dependencies.

This PR proposes to make these dependencies `optional`:

> `optional` lets other projects know that, when you use this project, you do not require this dependency in order to work correctly. ([source](https://maven.apache.org/pom.html))

## How was this patch tested?

Verified dependency tree of a project using Logredactor before / after this change.

Without excludes:

```
[INFO] +- org.cloudera.logredactor:logredactor:jar:2.0.14:runtime (optional)
[INFO] |  +- log4j:log4j:jar:1.2.17:runtime (optional)
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.17.1:runtime (optional)
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.17.1:runtime (optional)
```

With excludes:

```
[INFO] +- org.cloudera.logredactor:logredactor:jar:2.0.14:runtime (optional)
```

With this patch, excludes removed:

```
[INFO] +- org.cloudera.logredactor:logredactor:jar:2.0.15-SNAPSHOT:runtime (optional)
```

(Note that the downstream project declares `logredactor` as `optional`, but that doesn't affect Logredactor's transitive dependencies in that project.)