### PR TITLE
Bump jackson-databind to 2.15.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.15.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump jackson-databind to 2.15.3, since versions 2.12 - 2.14 are no longer active.

## How was this patch tested?

CI:
https://github.com/adoroszlai/logredactor/actions/runs/7813967087/job/21314215566