### PR TITLE
Replace log4j1 with reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
     </dependency>
     <dependency>
       <!-- Obsolete, but we have to support log4j version 1 -->
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>1.2.25</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `log4j` 1.x with `reload4j`, which is a drop-in replacement, with security updates.

## How was this patch tested?

CI:
https://github.com/adoroszlai/logredactor/actions/runs/7813937625/job/21314126817