### PR TITLE
Bump log4j2 to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,16 +139,14 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <!-- Matches Hive, the primary user of log4j2 -->
-      <version>2.17.1</version>
+      <version>2.22.1</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <!-- Matches Hive, the primary user of log4j2 -->
-      <version>2.17.1</version>
+      <version>2.22.1</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump log4j2 to 2.22.1, the latest release.  This should not affect users of `logredactor`, since logging dependencies are now optional.

## How was this patch tested?

CI:
https://github.com/adoroszlai/logredactor/actions/runs/7814599608/job/21316232327