### PR TITLE
Bump GitHub runner and actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,12 @@ on:
   - pull_request
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 8


### PR DESCRIPTION
`ubuntu-20.04` is no longer available, bump to `ubuntu-latest`.  Also bump `checkout` and `setup-java` actions to the latest versions.

CI:
https://github.com/adoroszlai/logredactor/actions/runs/20397973286